### PR TITLE
If digitial isn't defined on exit, don't error out

### DIFF
--- a/pyfirmata/pyfirmata.py
+++ b/pyfirmata/pyfirmata.py
@@ -294,9 +294,11 @@ class Board(object):
         """ Call this to exit cleanly. """
         # First detach all servo's, otherwise it somehow doesn't want to close...
         # FIXME
-        for pin in self.digital:
-            if pin.mode == SERVO:
-                pin.mode = OUTPUT
+        if hasattr(self, 'digital'):
+          for pin in self.digital:
+              if pin.mode == SERVO:
+                  pin.mode = OUTPUT
+
         if hasattr(self, 'sp'):
             self.sp.close()
         

--- a/tests.py
+++ b/tests.py
@@ -329,6 +329,17 @@ class RegressionTests(BoardBaseTest):
         self.assertEqual(self.board.digital[12].value, False)
         self.assertEqual(self.board.digital[13].value, None)
 
+    def test_proper_exit_conditions(self):
+      """
+      Test that the exit method works properly if we didn't make it all
+      the way through `setup_layout`.
+      """
+      del self.board.digital
+      try:
+        self.board.exit()
+      except:
+        self.fail("exit() raised an AttributeError unexpectedly!")
+
 
 board_messages = unittest.TestLoader().loadTestsFromTestCase(TestBoardMessages)
 board_layout = unittest.TestLoader().loadTestsFromTestCase(TestBoardLayout)


### PR DESCRIPTION
If an error occurs on initialization, the exit handler tries to access digital pins when they aren't defined.  This checks to see that the digital pins are defined before trying to access them
