### PR TITLE
Add Spark Core board layout and automatic names to shortcut classes

### DIFF
--- a/pyfirmata/__init__.py
+++ b/pyfirmata/__init__.py
@@ -5,6 +5,7 @@ __version__ = '0.9.5'  # Don't forget to change in setup.py!
 
 # shortcut classes
 
+# Arduino is-a Board
 class Arduino(Board):
     """
     A board that will set itself up as a normal Arduino.
@@ -13,6 +14,8 @@ class Arduino(Board):
         args = list(args)
         args.append(BOARDS['arduino'])
         super(Arduino, self).__init__(*args, **kwargs)
+        # forced name to 'arduino'
+        self.name = 'arduino'
 
     def __str__(self):
         return 'Arduino %s on %s' % (self.name, self.sp.port)
@@ -25,8 +28,18 @@ class ArduinoMega(Board):
     def __init__(self, *args, **kwargs):
         args = list(args)
         args.append(BOARDS['arduino_mega'])
-        self.name = 'arduino-mega'
         super(ArduinoMega, self).__init__(*args, **kwargs)
+        self.name = 'arduino_mega'
 
     def __str__(self):
         return 'Arduino Mega %s on %s' % (self.name, self.sp.port)
+
+class SparkCore(Board):
+    """
+    A board that will set itself up as a Spark Core
+    """
+    def __init__(self, *args, **kwargs):
+        args = list(args)
+        args.append(BOARDS['spark_core'])
+        super(SparkCore, self).__init__(*args, **kwargs)
+        self.name = 'spark_core'

--- a/pyfirmata/__init__.py
+++ b/pyfirmata/__init__.py
@@ -5,7 +5,6 @@ __version__ = '0.9.5'  # Don't forget to change in setup.py!
 
 # shortcut classes
 
-# Arduino is-a Board
 class Arduino(Board):
     """
     A board that will set itself up as a normal Arduino.
@@ -14,7 +13,6 @@ class Arduino(Board):
         args = list(args)
         args.append(BOARDS['arduino'])
         super(Arduino, self).__init__(*args, **kwargs)
-        # forced name to 'arduino'
         self.name = 'arduino'
 
     def __str__(self):

--- a/pyfirmata/__init__.py
+++ b/pyfirmata/__init__.py
@@ -25,6 +25,7 @@ class ArduinoMega(Board):
     def __init__(self, *args, **kwargs):
         args = list(args)
         args.append(BOARDS['arduino_mega'])
+        self.name = 'arduino-mega'
         super(ArduinoMega, self).__init__(*args, **kwargs)
 
     def __str__(self):

--- a/pyfirmata/boards.py
+++ b/pyfirmata/boards.py
@@ -12,5 +12,12 @@ BOARDS = {
         'pwm' : tuple(x for x in range(2,14)),
         'use_ports' : True,
         'disabled' : (0, 1) # Rx, Tx, Crystal
+    },
+    'spark_core' : {
+        'digital' : tuple(x for x in range(7)),
+        'analog' : tuple(x for x in range(10, 17)),
+        'pwm' : (0, 1, 10, 11, 14, 15, 16, 17),
+        'use_ports' : True,
+        'disabled' : (18, 19)
     }
 }

--- a/pyfirmata/boards.py
+++ b/pyfirmata/boards.py
@@ -14,10 +14,10 @@ BOARDS = {
         'disabled' : (0, 1) # Rx, Tx, Crystal
     },
     'spark_core' : {
-        'digital' : tuple(x for x in range(7)),
-        'analog' : tuple(x for x in range(10, 17)),
+        'digital' : tuple(x for x in range(20)),
+        'analog' : tuple(x for x in range(10, 18)),
         'pwm' : (0, 1, 10, 11, 14, 15, 16, 17),
         'use_ports' : True,
-        'disabled' : (18, 19)
+        'disabled' : (8, 9, 18, 19) # Rx, Tx, Crystal
     }
 }

--- a/tests.py
+++ b/tests.py
@@ -264,8 +264,9 @@ class TestBoardLayout(BoardBaseTest):
     def test_layout_spark_core(self):
         pyfirmata.pyfirmata.serial.Serial = mockup.MockupSerial
         spark = pyfirmata.Board('', BOARDS['spark_core'])
-        self.assertEqual(len(BOARDS['spark_core']['digital']), len(self.spark.digital))
-        self.assertEqual(len(BOARDS['spark_core']['analog']), len(self.spark.analog))
+        print len(BOARDS['spark_core']['digital']), spark.digital, spark.analog
+        self.assertEqual(len(BOARDS['spark_core']['digital']), len(spark.digital))
+        self.assertEqual(len(BOARDS['spark_core']['analog']), len(spark.analog))
 
     def test_pwm_layout(self):
         pins = []

--- a/tests.py
+++ b/tests.py
@@ -24,7 +24,6 @@ class BoardBaseTest(unittest.TestCase):
         self.board = pyfirmata.Board('', BOARDS['arduino'])
         self.board._stored_data = [] # FIXME How can it be that a fresh instance sometimes still contains data?
 
-
 class TestBoardMessages(BoardBaseTest):
     # TODO Test layout of Board Mega
     def assert_serial(self, *list_of_chrs):
@@ -261,6 +260,12 @@ class TestBoardLayout(BoardBaseTest):
         mega = pyfirmata.Board('', BOARDS['arduino_mega'])
         self.assertEqual(len(BOARDS['arduino_mega']['digital']), len(mega.digital))
         self.assertEqual(len(BOARDS['arduino_mega']['analog']), len(mega.analog))
+
+    def test_layout_spark_core(self):
+        pyfirmata.pyfirmata.serial.Serial = mockup.MockupSerial
+        spark = pyfirmata.Board('', BOARDS['spark_core'])
+        self.assertEqual(len(BOARDS['spark_core']['digital']), len(self.spark.digital))
+        self.assertEqual(len(BOARDS['spark_core']['analog']), len(self.spark.analog))
 
     def test_pwm_layout(self):
         pins = []


### PR DESCRIPTION
@tino I added [spark core's layout](http://docs.spark.io/hardware/#spark-core-datasheet-pins-and-i-o) to `pyfirmata.boards.BOARDS` with a layout test.

I also made the shortcut classes set `self.name` automatically according to the board type after calling super on the `Board` base class since it can be useful in implementing board-specific functions later.