### PR TITLE
Bugfix

### DIFF
--- a/pyfirmata/pyfirmata.py
+++ b/pyfirmata/pyfirmata.py
@@ -93,6 +93,7 @@ class Board(object):
         # TODO Find a more reliable way to wait until the board is ready
         self.pass_time(BOARD_SETUP_WAIT_TIME)
         self.name = name
+        self._layout = layout
         if not self.name:
             self.name = port
 
@@ -166,12 +167,12 @@ class Board(object):
         """
         Automatic setup based on Firmata's "Capability Query"
         """
-        self._set_default_handlers()
-        self.send_sysex(CAPABILITY_QUERY)
-        self.pass_time(0.1)  # Serial SYNC
+        self.add_cmd_handler(CAPABILITY_RESPONSE, self._handle_report_capability_response)
+        self.send_sysex(CAPABILITY_QUERY, [])
+        self.pass_time(0.1) # Serial SYNC
 
         while self.bytes_available():
-                self.iterate()
+            self.iterate()
 
         # handle_report_capability_response will write self._layout
         if self._layout:


### PR DESCRIPTION
The the commit picking has failed to catch some important modifications.
As it is now, pyFirmata won't handle Capability Query correctly:
* CAPABILITY_RESPONSE handler was not registered
* auto_setup calls send_sysex incorrectly
* _layouts is missing. Therefore, setup_layout and _handle_report_capability_response won't communicate

This bug is my fault, due to incorrect testing.
