### PR TITLE
Make Iterator a daemon for proper exit

### DIFF
--- a/pyfirmata/util.py
+++ b/pyfirmata/util.py
@@ -2,7 +2,7 @@ from __future__ import division
 from __future__ import unicode_literals
 import threading
 import time
-import os
+import os, sys
 
 import serial
 
@@ -39,6 +39,7 @@ class Iterator(threading.Thread):
     def __init__(self, board):
         super(Iterator, self).__init__()
         self.board = board
+        self.daemon = True
 
     def run(self):
         while 1:
@@ -63,6 +64,8 @@ class Iterator(threading.Thread):
                     pass
                 raise
 
+            except (KeyboardInterrupt) as e:
+                sys.exit()
 
 def to_two_bytes(integer):
     """


### PR DESCRIPTION
As per this [issue](https://github.com/tino/pyFirmata/issues/13) I have added `self.daemon = True` to `Iterator`'s constructor thus upon the termination of the main thread the daemon thread will die.

``` python
>>> it = util.Iterator(board)
>>> it.start()
>>> it.is_alive()    # -> True
>>> quit()           # Used to hang, now terminates
```

If a test case is required for this, I'll write that and issue in another request.

> The entire Python program exits when no alive non-daemon threads are left.
> https://docs.python.org/3/library/threading.html#threading.Thread.daemon
