### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,9 +54,9 @@ Otherwise the board will keep sending data to your serial, until it overflows::
 
 If you use a pin more often, it can be worth it to use the ``get_pin`` method
 of the board. It let's you specify what pin you need by a string, composed of
-'a' or 'd' (depending on wether you need an analog or digital pin), the pin
+'a' or 'd' (depending on whether you need an analog or digital pin), the pin
 number, and the mode ('i' for input, 'o' for output, 'p' for pwm). All
-seperated by ``:``. Eg. ``a:0:i`` for analog 0 as input or ``d:3:p`` for
+separated by ``:``. Eg. ``a:0:i`` for analog 0 as input or ``d:3:p`` for
 digital pin 3 as pwm.::
 
     >>> analog_0 = board.get_pin('a:0:i')

--- a/pyfirmata/pyfirmata.py
+++ b/pyfirmata/pyfirmata.py
@@ -205,7 +205,7 @@ class Board(object):
         'd' digital pin    Pin number   'o' for output
                                         'p' for pwm (Pulse-width modulation)
 
-        All seperated by ``:``.
+        All separated by ``:``.
         """
         if type(pin_def) == list:
             bits = pin_def
@@ -272,7 +272,7 @@ class Board(object):
         received_data = []
         handler = None
         if data < START_SYSEX:
-            # These commands can have 'channel data' like a pin nummber appended.
+            # These commands can have 'channel data' like a pin number appended.
             try:
                 handler = self._command_handlers[data & 0xF0]
             except KeyError:


### PR DESCRIPTION
There are small typos in:
- README.rst
- pyfirmata/pyfirmata.py

Fixes:
- Should read `separated` rather than `seperated`.
- Should read `whether` rather than `wether`.
- Should read `number` rather than `nummber`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md