### PR TITLE
Removing deprecated since Python 3.0 warning

### DIFF
--- a/pyfirmata/pyfirmata.py
+++ b/pyfirmata/pyfirmata.py
@@ -182,7 +182,7 @@ class Board(object):
 
     def add_cmd_handler(self, cmd, func):
         """Adds a command handler for a command."""
-        len_args = len(inspect.getargspec(func)[0])
+        len_args = len(inspect.getfullargspec(func)[0])
 
         def add_meta(f):
             def decorator(*args, **kwargs):


### PR DESCRIPTION
Removing a warning due to deprecation. 

Warning:
pyfirmata/pyfirmata.py:185: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()

len_args = len(inspect.getargspec(func)[0])